### PR TITLE
Develop

### DIFF
--- a/doc/source/dummy_module.hy
+++ b/doc/source/dummy_module.hy
@@ -8,7 +8,7 @@ some additional text"
 
 ;; TODO Module documenter doesn't pull macros
 (defmacro defall [#* symbols]
-  "Defines `--all--` using unmangled hy names"
+  "Defines `__all__` using unmangled hy names"
   `(setv __all__ ~(lfor sym symbols (mangle sym))))
 
 (defmacro optionalmacro [a [b None]])
@@ -37,7 +37,9 @@ some additional text"
 
 (defall
   optionalfunc
-  a-func? Point adecorator MyError GLOBAL-VAR Vector async-func obj-param-test optional-bug ^)
+  a-func? Point adecorator MyError GLOBAL-VAR Vector
+  async-func obj-param-test optional-bug ^ ->something
+  )
 
 ;; TODO
 (setv GLOBAL-VAR "hello world")
@@ -62,6 +64,9 @@ some additional text"
   "Hello World!"
   (+ a b))
 
+(defn ->something [a b c]
+  "leading dash not converted to underscore")
+
 (defn/a async-func [a])
 
 (defn adecorator [f]
@@ -79,7 +84,7 @@ some additional text"
   ;; (setv Vector (of list float))
   ;; "New Attribute Type"
 
-  (defn --init-- [self x y]
+  (defn __init__ [self x y]
     ;; TODO
     (setv self.x x)
     "location on the x axis"
@@ -111,11 +116,10 @@ some additional text"
       (defn method_to_implement [self input]))
 
   #@(final
-      (defn final-method [self]))
-  )
+      (defn final-method [self])))
 
 ;; TODO
 
 #@(final
     (defclass MyError [Exception]
-      (defn --init-- [self a b c])))
+      (defn __init__ [self a b c])))

--- a/sphinxcontrib/hydomain.py
+++ b/sphinxcontrib/hydomain.py
@@ -553,13 +553,14 @@ class HyFunction(HyObject):
 
 
 class HyMacro(HyFunction):
-    pass
+    def get_signature_prefix(self, sig: str) -> str:
+        return self.objtype
 
 
 class HyTag(HyFunction):
     def add_target_and_index(self, name_cls: Tuple[str, str], sig: str, signode):
         modname = self.options.get("module", self.env.ref_context.get("hy:module"))
-        fullname = (modname + "." if modname else "") + "#" + name_cls[0]
+        fullname = (modname + "." if modname else "") + name_cls[0]
         # node_id = make_id(self.env, self.state.document, "", fullname)
         node_id = fullname
         signode["ids"].append(node_id)
@@ -626,7 +627,7 @@ class HyTag(HyFunction):
         if sig_prefix:
             signode += addnodes.desc_annotation(sig_prefix, sig_prefix)
 
-        signode += addnodes.desc_addname("#", "#")
+        # signode += addnodes.desc_addname("#", "#")
 
         if add_module and self.env.config.add_module_names:
             if modname and modname != "exceptions":


### PR DESCRIPTION
* Fixed: duplicate `#` in tag documentation after merging of `__tags__` and `__macros__`
* Added: the prefix `macro` to macros to telegraph that they need to be `require`'d instead of `import`'d